### PR TITLE
Initial version of gutter error messages using the new Textmate API

### DIFF
--- a/Support/renderer/gutter/renderer.js
+++ b/Support/renderer/gutter/renderer.js
@@ -1,0 +1,30 @@
+/* jshint node: true */
+(function () {
+	'use strict';
+
+	var cp = require('child_process'),
+		MATE = '/usr/local/bin/mate';
+
+	function render(errors) {
+		// clear existing marks in the current file
+		var markCleaner = cp.spawn(MATE, ['--clear-mark', 'warning', process.env.TM_FILEPATH]);
+
+		// don't render gutter marks if there were no errors
+		if (errors.length === 0) {
+			return false;
+		}
+
+		// render gutter marks, but first, wait for the clearer command to finish
+		markCleaner.on('close', function () {
+			errors.forEach(function (err) {
+				if (err.file === process.env.TM_FILEPATH) {
+					cp.spawn(MATE, ['--set-mark', 'warning:"' + err.message + '"', '--line', err.line, err.file]);
+				}
+			});
+		});
+	}
+
+	module.exports = function (errors) {
+		render(errors);
+	};
+}());

--- a/Support/run.js
+++ b/Support/run.js
@@ -33,7 +33,7 @@ getJson = function (runners) {
  * Render data with the requested renderer
  */
 render = function (jsonData) {
-	var reporter;
+	var reporter, gutterReporter;
 	switch (cmdOpts.options.renderer) {
 	case 'tooltip':
 		reporter = require('./renderer/tooltip/renderer');
@@ -43,6 +43,10 @@ render = function (jsonData) {
 		break;
 	}
 	reporter(jsonData);
+
+	// render gutter
+	gutterReporter = require('./renderer/gutter/renderer');
+	gutterReporter(jsonData);
 };
 
 /**


### PR DESCRIPTION
This change adds warning images to the gutter on each line where a hinter error is found. Gutter images were introduced in `v2.0-beta.3`, so make sure your updated to that version, and you have the command line tools installed!

![screenshot 2014-10-25 02 13 06](https://cloud.githubusercontent.com/assets/710358/4778047/bf6a446a-5bdb-11e4-91b8-947ddf9ea8a8.png)

As you can see, gutter images are work in progress in Textmate, but I'll update the plugin if the API changes.
