### PR TITLE
Fix issue where error is thrown if mate isn't at /usr/local/bin/mate

### DIFF
--- a/Support/renderer/gutter/renderer.js
+++ b/Support/renderer/gutter/renderer.js
@@ -4,7 +4,7 @@
 
 	var cp = require('child_process'),
 		Q = require('q'),
-		MATE = '/usr/local/bin/mate',
+		MATE = process.env.TM_MATE,
 		gutterImage = 'warning',
 		currentFile = process.env.TM_FILEPATH;
 


### PR DESCRIPTION
Change hard-coded path to `process.env.TM_MATE`.

Fixes https://github.com/bodnaristvan/JavascriptHinter.tmbundle/issues/4.