### PR TITLE
Scss, eslint, and gjslint

### DIFF
--- a/Support/hint-connectors/eslint/connector.js
+++ b/Support/hint-connectors/eslint/connector.js
@@ -1,0 +1,51 @@
+/**
+ * JavascriptHinter - eslint connector
+ * Runs the installed eslint version with the default JSON reporter and parses the output
+ * into a JS object
+ */
+var path = require('path'),
+  getJsonOutput = require('../helpers/getjsonoutput'),
+  Q = require('q');
+
+module.exports = {
+  /**
+   * Process the file using eslint
+   * @param {Array} files Array of files to check with the specified linter
+   * @returns {Q.Promise} Returns a promise that is resolved when the output is parsed to a JS object
+   */
+  process: function (files) {
+    var def = Q.defer();
+    var fileDir = path.dirname(files[0]);
+    var args = ['--config', '/Users/heathg/.eslintrc', '--format', 'JSON'].concat(files);
+    var originalOutput = getJsonOutput('eslint', args, {cwd: fileDir});
+
+    // original JSON output needs to be transformed so it can be used with the default renderer & tooltip
+    originalOutput
+      .then(function (output) {
+        var errors = [];
+        var fileErrors = output.map(function (file) {
+          return file.messages.map(function(message) {
+            return {
+              hinttype: 'eslint',
+              file: file.filePath,
+              line: message.line,
+              column: message.column,
+              evidence: message.source || '',
+              message: message.message + (message.linter ? ' (' + message.linter + ')' : ''),
+              rule: file.code
+            }
+          });
+        });
+
+        for (var i = fileErrors.length - 1; i >= 0; i--) {
+          for (var ii = fileErrors[i].length - 1; ii >= 0; ii--) {
+            errors.push(fileErrors[i][ii])
+          }
+        }
+
+        def.resolve(errors);
+      }, def.reject)
+      .done();
+    return def.promise;
+  }
+};

--- a/Support/hint-connectors/gjslint/connector.js
+++ b/Support/hint-connectors/gjslint/connector.js
@@ -1,0 +1,24 @@
+/**
+ * Google Closure Linter - gjslint connector
+ * Runs the installed gjslint version with and uses getJsonGJSLintOutput parses
+ * the output into a JS object
+ */
+var path = require('path'),
+  getJsonGJSLintOutput = require('./getjsongjslintoutput');
+
+module.exports = {
+  /**
+   * Process the file using gjslint
+   *
+   * @param {Array} files Array of files to check with the specified linter
+   * @returns {Q.Promise} Returns a promise that is resolved when the output is
+   *     parsed to a JS object
+   */
+  process: function(files) {
+    var fileDir = path.dirname(files[0]),
+      args = [
+        '--nobeep', '--nosummary', '--quiet'
+      ].concat(files);
+    return getJsonGJSLintOutput('gjslint', args, {cwd: fileDir});
+  }
+};

--- a/Support/hint-connectors/gjslint/getjsongjslintoutput.js
+++ b/Support/hint-connectors/gjslint/getjsongjslintoutput.js
@@ -1,0 +1,55 @@
+/**
+ * This runner executes a linter process and collects the output from stdout.
+ * The expected output from the linter is JSON that can be parsed by the renderer.
+ */
+var Q = require('q'),
+  cp = require('child_process'),
+  getJsonGJSLintOutput;
+
+
+
+/**
+ * Get the json output from the linter
+ * @param {String} runnable - Name of the executable to run
+ * @param {Array} args - Command line arguments to pass
+ * @param {Object} options - Options to set on process.spawn
+ * @returns {Q.Promise} Returns a promise that is resolved when executable finishes running
+ */
+getJsonGJSLintOutput = function (runnable, args, options) {
+  var def = Q.defer(),
+    dataConcat = '',
+    proc = cp.spawn(runnable, args, options || {}),
+    regex = new RegExp(/^Line (\d+), E:([^:]+): (.+)$/gm);
+
+  proc.stdout.on('data', function (data) {
+    dataConcat = dataConcat + data;
+  });
+
+  proc.on('close', function () {
+    var lineData = [];
+    try {
+      var  matchTest = dataConcat.match(/^.*((\r\n|\n|\r)|$)/gm);
+      for (var match of matchTest) {
+        var matchObject = {
+          file: matchTest[0],
+          hinttype: 'gjslint',
+          column: '',
+          evidence: ''
+        };
+        var matchMatches = regex.exec(match);
+        if (matchMatches) {
+          matchObject.line = matchMatches[1];
+          matchObject.message = 'E:' + matchMatches[2]+': ' + matchMatches[3];
+          lineData.push(matchObject)
+        }
+      }
+    } catch (e) {
+      lineData = [];
+    }
+    def.resolve(lineData);
+  });
+
+  return def.promise;
+};
+
+module.exports = getJsonGJSLintOutput;

--- a/Support/hint-connectors/scsslint/connector.js
+++ b/Support/hint-connectors/scsslint/connector.js
@@ -15,10 +15,10 @@ module.exports = {
 	 * parsed to a JS object.
 	 */
 	process: function (files) {
-		var def = Q.defer();
-		var fileDir = path.dirname(files[0]);
-		var args = ['--format', 'JSON'].concat(files);
-		var originalOutput = getJsonOutput('scss-lint', args, {cwd: fileDir});
+		var def = Q.defer(),
+			fileDir = path.dirname(files[0]),
+			args = ['--format', 'JSON'].concat(files),
+			originalOutput = getJsonOutput('scss-lint', args, {cwd: fileDir});
 
 		/**
 		 * Original JSON output needs to be transformed so it can be used with the

--- a/Support/hint-connectors/scsslint/connector.js
+++ b/Support/hint-connectors/scsslint/connector.js
@@ -4,43 +4,43 @@
  * parses the output into a JS object.
  */
 var path = require('path'),
-  getJsonOutput = require('../helpers/getjsonoutput'),
-  Q = require('q');
+	getJsonOutput = require('../helpers/getjsonoutput'),
+	Q = require('q');
 
 module.exports = {
-  /**
-   * Process the file using scss-lint
-   * @param {Array} files Array of files to check with the specified linter
-   * @returns {Q.Promise} Returns a promise that is resolved when the output is
-   * parsed to a JS object.
-   */
-  process: function (files) {
-    var def = Q.defer();
-    var fileDir = path.dirname(files[0]);
-    var args = ['--format', 'JSON'].concat(files);
-    var originalOutput = getJsonOutput('scss-lint', args, {cwd: fileDir});
+	/**
+	 * Process the file using scss-lint
+	 * @param {Array} files Array of files to check with the specified linter
+	 * @returns {Q.Promise} Returns a promise that is resolved when the output is
+	 * parsed to a JS object.
+	 */
+	process: function (files) {
+		var def = Q.defer();
+		var fileDir = path.dirname(files[0]);
+		var args = ['--format', 'JSON'].concat(files);
+		var originalOutput = getJsonOutput('scss-lint', args, {cwd: fileDir});
 
-    /**
-     * Original JSON output needs to be transformed so it can be used with the
-     * default renderer & tooltip.
-     */
-    originalOutput
-      .then(function (output) {
-        var errors = (output[files[0]]||[]).map(function (error) {
-          return {
-            hinttype: 'scss',
-            file: files[0],
-            line: error.line,
-            column: error.column,
-            evidence: error.evidence || '',
-            message: error.reason +
-                (error.linter ? ' (' + error.linter + ')' : ''),
-            rule: error.code
-          };
-        });
-        def.resolve(errors);
-      }, def.reject)
-      .done();
-    return def.promise;
-  }
+		/**
+		 * Original JSON output needs to be transformed so it can be used with the
+		 * default renderer & tooltip.
+		 */
+		originalOutput
+			.then(function (output) {
+				var errors = (output[files[0]]||[]).map(function (error) {
+					return {
+						hinttype: 'scss',
+						file: files[0],
+						line: error.line,
+						column: error.column,
+						evidence: error.evidence || '',
+						message: error.reason +
+								(error.linter ? ' (' + error.linter + ')' : ''),
+						rule: error.code
+					};
+				});
+				def.resolve(errors);
+			}, def.reject)
+			.done();
+		return def.promise;
+	}
 };

--- a/Support/hint-connectors/scsslint/connector.js
+++ b/Support/hint-connectors/scsslint/connector.js
@@ -1,0 +1,50 @@
+/**
+ * JavascriptHinter - scss-lint connector
+ * Runs the installed scss-lint version with the default JSON reporter and
+ * parses the output into a JS object.
+ */
+var path = require('path'),
+  getJsonOutput = require('../helpers/getjsonoutput'),
+  Q = require('q');
+
+module.exports = {
+  /**
+   * Process the file using scss-lint
+   * @param {Array} files Array of files to check with the specified linter
+   * @returns {Q.Promise} Returns a promise that is resolved when the output is
+   * parsed to a JS object.
+   */
+  process: function (files) {
+    var def = Q.defer();
+    var fileDir = path.dirname(files[0]);
+    var args = [
+      '--config',
+      '/Users/heathg/.scss-lint.yml',
+      '--format',
+      'JSON'].concat(files);
+    var originalOutput = getJsonOutput('scss-lint', args, {cwd: fileDir});
+
+    /**
+     * Original JSON output needs to be transformed so it can be used with the
+     * default renderer & tooltip.
+     */
+    originalOutput
+      .then(function (output) {
+        var errors = (output[files[0]]||[]).map(function (error) {
+          return {
+            hinttype: 'scss',
+            file: files[0],
+            line: error.line,
+            column: error.column,
+            evidence: error.evidence || '',
+            message: error.reason +
+                (error.linter ? ' (' + error.linter + ')' : ''),
+            rule: error.code
+          };
+        });
+        def.resolve(errors);
+      }, def.reject)
+      .done();
+    return def.promise;
+  }
+};

--- a/Support/renderer/tooltip/tooltip-renderer.html
+++ b/Support/renderer/tooltip/tooltip-renderer.html
@@ -1,5 +1,5 @@
 {{#if numErrors}}JavascriptHinter found {{numErrors}} problems:
 
-{{#each errors}}Line {{line}}: {{{message}}}
+{{#each errors}}[{{hinttype}}] Line {{line}}: {{{message}}}
 {{/each}}
 {{else}}Lint-free!{{/if}}

--- a/Support/run.js
+++ b/Support/run.js
@@ -11,6 +11,7 @@ getRunners = function () {
 		jscsConnector = require('./hint-connectors/jscs/connector'),
 		scsslintConnector = require('./hint-connectors/scsslint/connector'),
 		eslintConnector = require('./hint-connectors/eslint/connector'),
+		gjslintConnector = require('./hint-connectors/gjslint/connector'),
 		files = cmdOpts.argv,
 		connectors;
 
@@ -20,7 +21,8 @@ getRunners = function () {
 		connectors = [
 			jshintConnector.process(files),
 			eslintConnector.process(files),
-			jscsConnector.process(files)
+			jscsConnector.process(files),
+			gjslintConnector.process(files)
 		];
 	}
 	return connectors;

--- a/Support/run.js
+++ b/Support/run.js
@@ -9,9 +9,21 @@ var Q = require('q'),
 getRunners = function () {
 	var jshintConnector = require('./hint-connectors/jshint/connector'),
 		jscsConnector = require('./hint-connectors/jscs/connector'),
-		files = cmdOpts.argv;
+		scsslintConnector = require('./hint-connectors/scsslint/connector'),
+		eslintConnector = require('./hint-connectors/eslint/connector'),
+		files = cmdOpts.argv,
+		connectors;
 
-	return [jshintConnector.process(files), jscsConnector.process(files)];
+	if (files[0].indexOf('.scss') !== -1) {
+		connectors = [scsslintConnector.process(files)];
+	} else {
+		connectors = [
+			jshintConnector.process(files),
+			eslintConnector.process(files),
+			jscsConnector.process(files)
+		];
+	}
+	return connectors;
 };
 
 /**
@@ -45,8 +57,10 @@ render = function (jsonData) {
 	reporter(jsonData);
 
 	// render gutter
-	gutterReporter = require('./renderer/gutter/renderer');
-	gutterReporter(jsonData);
+	if (process.env.TM_MATE) {
+		gutterReporter = require('./renderer/gutter/renderer');
+		gutterReporter(jsonData);
+	}
 };
 
 /**


### PR DESCRIPTION
Add gjslint with regex based "reporter" that converts line output to json.

https://atom.io/packages/linter

Separate pull request for adding GJSLint with the SCSS and ESLinter.

I'm hoping we're getting closer and closer to the awesome Atom Linter Plugin, that has simple configs that enable any linter to work with Atom.
